### PR TITLE
Slow down Contact Us animation

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -142,7 +142,7 @@ export default {
                                 'float': 'float 3s ease-in-out infinite',
                                 'glow': 'glow 2s ease-in-out infinite',
                                 'slide-up': 'slide-up 0.5s ease-out',
-                               'bounce-scale': 'bounce-scale 3s ease-in-out infinite'
+                               'bounce-scale': 'bounce-scale 5s ease-in-out infinite'
                         }
                 }
         },


### PR DESCRIPTION
## Summary
- make the bounce-scale animation slower

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68414840f4c48333a895b0381817556a