### PR TITLE
Improve popup charts

### DIFF
--- a/src/components/DashboardPopup.tsx
+++ b/src/components/DashboardPopup.tsx
@@ -7,16 +7,31 @@ interface DashboardPopupProps {
   data: RevenuePoint[];
 }
 
-const DashboardPopup = ({ children, data }: DashboardPopupProps) => (
-  <Dialog>
-    <DialogTrigger asChild>{children}</DialogTrigger>
-    <DialogContent className="bg-gray-900">
-      <h3 className="text-lg font-semibold mb-4 text-center text-white">
-        Revenue - Last 30 Days
-      </h3>
-      <RevenueChart data={data} />
-    </DialogContent>
-  </Dialog>
-);
+const DashboardPopup = ({ children, data }: DashboardPopupProps) => {
+  const total = data.reduce((acc, curr) => acc + curr.revenue, 0);
+  const streams = data.length;
+  const hours = streams * 3;
+
+  return (
+    <Dialog>
+      <DialogTrigger asChild>{children}</DialogTrigger>
+      <DialogContent className="bg-gray-900 text-white">
+        <h3 className="text-lg font-semibold mb-4 text-center">
+          Revenue - Last 30 Days
+        </h3>
+        <RevenueChart data={data} />
+        <div className="mt-4 text-center text-sm space-y-1">
+          <div>
+            Total earned:{' '}
+            <span className="text-twitch font-semibold">
+              {'$' + total.toLocaleString()}
+            </span>
+          </div>
+          <div>Streams: {streams} • Hours: {hours}</div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};
 
 export default DashboardPopup;

--- a/src/components/RevenueChart.tsx
+++ b/src/components/RevenueChart.tsx
@@ -1,4 +1,6 @@
 import { ResponsiveContainer, LineChart, Line, XAxis, YAxis, Tooltip } from 'recharts';
+import type { TooltipProps } from 'recharts';
+import type { ValueType, NameType } from 'recharts/types/component/DefaultTooltipContent';
 
 export interface RevenuePoint {
   date: string;
@@ -9,14 +11,26 @@ interface RevenueChartProps {
   data: RevenuePoint[];
 }
 
+const CustomTooltip = ({ active, payload, label }: TooltipProps<ValueType, NameType>) => {
+  if (active && payload && payload.length) {
+    return (
+      <div className="bg-gray-800 text-white text-sm px-3 py-2 rounded shadow-lg">
+        <p>{label}</p>
+        <p className="text-twitch font-semibold">${payload[0].value}</p>
+      </div>
+    );
+  }
+  return null;
+};
+
 const RevenueChart = ({ data }: RevenueChartProps) => (
   <div className="h-72 w-full">
     <ResponsiveContainer width="100%" height="100%">
       <LineChart data={data} margin={{ top: 10, right: 30, left: 0, bottom: 0 }}>
         <XAxis dataKey="date" hide />
         <YAxis hide />
-        <Tooltip cursor={{ stroke: '#9145FE', strokeWidth: 2 }} />
-        <Line type="monotone" dataKey="revenue" stroke="#9145FE" strokeWidth={2} dot={false} />
+        <Tooltip cursor={{ stroke: '#9145FE', strokeWidth: 2 }} content={<CustomTooltip />} />
+        <Line type="monotone" dataKey="revenue" stroke="#9145FE" strokeWidth={2} dot={{ r: 3 }} activeDot={{ r: 5 }} />
       </LineChart>
     </ResponsiveContainer>
   </div>

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -42,7 +42,7 @@ const DialogContent = React.forwardRef<
       {...props}
     >
       {children}
-      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 transition-opacity text-twitch hover:opacity-100 focus:outline-none">
         <X className="h-4 w-4" />
         <span className="sr-only">Close</span>
       </DialogPrimitive.Close>


### PR DESCRIPTION
## Summary
- style popup close buttons in purple
- add tooltip and point details on revenue charts
- display revenue totals below charts

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68414bde971083338275f11f51e01c8e