### PR TITLE
Improve revenue chart details

### DIFF
--- a/src/components/RevenueChart.tsx
+++ b/src/components/RevenueChart.tsx
@@ -11,12 +11,14 @@ interface RevenueChartProps {
   data: RevenuePoint[];
 }
 
-const CustomTooltip = ({ active, payload, label }: TooltipProps<ValueType, NameType>) => {
+const CustomTooltip = (
+  { active, payload, label }: TooltipProps<ValueType, NameType>
+) => {
   if (active && payload && payload.length) {
     return (
-      <div className="bg-gray-800 text-white text-sm px-3 py-2 rounded shadow-lg">
+      <div className="rounded-md bg-gray-800/80 px-3 py-2 text-xs text-white shadow-lg backdrop-blur-sm">
         <p>{label}</p>
-        <p className="text-twitch font-semibold">${payload[0].value}</p>
+        <p className="font-semibold text-twitch">${payload[0].value}</p>
       </div>
     );
   }
@@ -29,8 +31,18 @@ const RevenueChart = ({ data }: RevenueChartProps) => (
       <LineChart data={data} margin={{ top: 10, right: 30, left: 0, bottom: 0 }}>
         <XAxis dataKey="date" hide />
         <YAxis hide />
-        <Tooltip cursor={{ stroke: '#9145FE', strokeWidth: 2 }} content={<CustomTooltip />} />
-        <Line type="monotone" dataKey="revenue" stroke="#9145FE" strokeWidth={2} dot={{ r: 3 }} activeDot={{ r: 5 }} />
+        <Tooltip
+          cursor={{ stroke: '#9145FE', strokeWidth: 2 }}
+          content={<CustomTooltip />}
+        />
+        <Line
+          type="monotone"
+          dataKey="revenue"
+          stroke="#9145FE"
+          strokeWidth={2}
+          dot={{ r: 4, stroke: '#9145FE', strokeWidth: 2, fill: '#9145FE' }}
+          activeDot={{ r: 6 }}
+        />
       </LineChart>
     </ResponsiveContainer>
   </div>


### PR DESCRIPTION
## Summary
- refine chart tooltip style for a smoother display
- highlight each day on the revenue chart with visible dots

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68414d0236e08333b2b075bd9e6f233a