### PR TITLE
Improve streamer popup with unique stats

### DIFF
--- a/src/components/DashboardPopup.tsx
+++ b/src/components/DashboardPopup.tsx
@@ -2,32 +2,43 @@ import { ReactNode } from 'react';
 import { Dialog, DialogContent, DialogTrigger } from '@/components/ui/dialog';
 import RevenueChart, { RevenuePoint } from './RevenueChart';
 
+interface StreamerStats {
+  moneyEarned: number;
+  increasePercent: number;
+}
+
 interface DashboardPopupProps {
   children: ReactNode;
   data: RevenuePoint[];
+  stats: StreamerStats;
 }
 
-const DashboardPopup = ({ children, data }: DashboardPopupProps) => {
-  const total = data.reduce((acc, curr) => acc + curr.revenue, 0);
-  const streams = data.length;
+const DashboardPopup = ({ children, data, stats }: DashboardPopupProps) => {
+  const streams = data.reduce((acc, curr) => acc + curr.revenue, 0);
   const hours = streams * 3;
 
   return (
     <Dialog>
       <DialogTrigger asChild>{children}</DialogTrigger>
-      <DialogContent className="bg-gray-900 text-white">
+      <DialogContent
+        className="bg-gray-900 text-white border border-twitch/40 shadow-[0_0_30px_#9145FE] animate-glow"
+      >
         <h3 className="text-lg font-semibold mb-4 text-center">
-          Revenue - Last 30 Days
+          Streams - Last 30 Days
         </h3>
         <RevenueChart data={data} />
         <div className="mt-4 text-center text-sm space-y-1">
           <div>
-            Total earned:{' '}
+            Earned with us:{' '}
             <span className="text-twitch font-semibold">
-              {'$' + total.toLocaleString()}
+              {'$' + stats.moneyEarned.toLocaleString()}
             </span>
           </div>
-          <div>Streams: {streams} • Hours: {hours}</div>
+          <div className="text-green-400">
+            +{stats.increasePercent}% revenue
+          </div>
+          <div>Streams this month: {streams}</div>
+          <div className="font-semibold text-twitch">Hours streamed: {hours}h</div>
         </div>
       </DialogContent>
     </Dialog>

--- a/src/components/RevenueChart.tsx
+++ b/src/components/RevenueChart.tsx
@@ -18,7 +18,7 @@ const CustomTooltip = (
     return (
       <div className="rounded-md bg-gray-800/80 px-3 py-2 text-xs text-white shadow-lg backdrop-blur-sm">
         <p>{label}</p>
-        <p className="font-semibold text-twitch">${payload[0].value}</p>
+        <p className="font-semibold text-twitch">{payload[0].value} streams</p>
       </div>
     );
   }

--- a/src/components/TestimonialCard.tsx
+++ b/src/components/TestimonialCard.tsx
@@ -8,12 +8,13 @@ interface TestimonialCardProps {
   earnings: string;
   imageLeft: boolean;
   showConnector?: boolean;
-  revenueData?: RevenuePoint[];
+  streamData?: RevenuePoint[];
+  stats: { moneyEarned: number; increasePercent: number };
 }
 
-const TestimonialCard = ({ name, testimonial, earnings, imageLeft, showConnector = true, revenueData }: TestimonialCardProps) => {
+const TestimonialCard = ({ name, testimonial, earnings, imageLeft, showConnector = true, streamData, stats }: TestimonialCardProps) => {
   const chartData =
-    revenueData ||
+    streamData ||
     Array.from({ length: 30 }, (_, i) => ({
       date: `Day ${i + 1}`,
       revenue: 800 + i * 20 + Math.round(Math.sin(i / 3) * 100)
@@ -24,7 +25,7 @@ const TestimonialCard = ({ name, testimonial, earnings, imageLeft, showConnector
       <div className={`flex flex-col lg:flex-row items-center gap-12 ${imageLeft ? 'lg:flex-row' : 'lg:flex-row-reverse'}`}>
         {/* Dashboard Screenshot */}
         <div className="flex-1 relative">
-          <DashboardPopup data={chartData}>
+          <DashboardPopup data={chartData} stats={stats}>
             <div className="bg-gray-900 rounded-lg p-4 border border-twitch/30 relative overflow-hidden cursor-pointer hover:shadow-lg transition-shadow">
               <div className="absolute inset-0 bg-gradient-to-br from-twitch/10 to-transparent"></div>
               <div className="relative">

--- a/src/pages/Services.tsx
+++ b/src/pages/Services.tsx
@@ -3,6 +3,14 @@ import AnimatedCounter from '@/components/AnimatedCounter';
 import TestimonialCard from '@/components/TestimonialCard';
 import { Button } from '@/components/ui/button';
 
+import type { RevenuePoint } from '@/components/RevenueChart';
+
+const generateStreams = (offset: number, amp: number): RevenuePoint[] =>
+  Array.from({ length: 30 }, (_, i) => ({
+    date: `Day ${i + 1}`,
+    revenue: Math.max(0, Math.round(Math.sin(i / 3 + offset) * amp + amp))
+  }));
+
 interface ServicesProps {
   onBackHome?: () => void;
 }
@@ -12,25 +20,33 @@ const testimonialData = [
     name: "TechGamer99",
     testimonial: "Working with Wammy's Agency has been a game-changer for my streaming career. They helped me increase my ad revenue by 400% while maintaining my authentic content style.",
     earnings: "$3,200",
-    imageLeft: true
+    imageLeft: true,
+    streamData: generateStreams(1, 3),
+    stats: { moneyEarned: 3200, increasePercent: 400 }
   },
   {
     name: "StreamQueen",
     testimonial: "The professionalism and results speak for themselves. In just 3 months, I went from struggling to pay bills to having a stable income from streaming.",
     earnings: "$2,800",
-    imageLeft: false
+    imageLeft: false,
+    streamData: generateStreams(2, 4),
+    stats: { moneyEarned: 2800, increasePercent: 350 }
   },
   {
     name: "GamingMaster",
     testimonial: "I was skeptical at first, but Wammy's delivered exactly what they promised. The ad optimization strategies they implemented are incredible.",
     earnings: "$4,100",
-    imageLeft: true
+    imageLeft: true,
+    streamData: generateStreams(0.5, 5),
+    stats: { moneyEarned: 4100, increasePercent: 420 }
   },
   {
     name: "RetroStreamer",
     testimonial: "Finally, an agency that understands Twitch and actually cares about their partners' success. The transparency and support are unmatched.",
     earnings: "$2,500",
-    imageLeft: false
+    imageLeft: false,
+    streamData: generateStreams(1.5, 2),
+    stats: { moneyEarned: 2500, increasePercent: 275 }
   }
 ];
 
@@ -95,6 +111,8 @@ const Services = ({ onBackHome }: ServicesProps) => {
                 testimonial={testimonial.testimonial}
                 earnings={testimonial.earnings}
                 imageLeft={testimonial.imageLeft}
+                streamData={testimonial.streamData}
+                stats={testimonial.stats}
                 showConnector={index < testimonialData.length - 1}
               />
             ))}


### PR DESCRIPTION
## Summary
- add violet glow and new stats to DashboardPopup
- update RevenueChart tooltip wording
- allow TestimonialCard to take custom stream data and stats
- generate unique stream data and stats per testimonial

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found due to restricted environment)*

------
https://chatgpt.com/codex/tasks/task_e_68414efc0af08333a367aff4d81dbd56