### PR TITLE
Fix dashboard popup auto-closing

### DIFF
--- a/src/components/DashboardPopup.tsx
+++ b/src/components/DashboardPopup.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react';
+import { ReactNode, useState } from 'react';
 import { Dialog, DialogContent, DialogTrigger } from '@/components/ui/dialog';
 import RevenueChart, { RevenuePoint } from './RevenueChart';
 
@@ -17,8 +17,10 @@ const DashboardPopup = ({ children, data, stats }: DashboardPopupProps) => {
   const streams = data.reduce((acc, curr) => acc + curr.revenue, 0);
   const hours = streams * 3;
 
+  const [open, setOpen] = useState(false);
+
   return (
-    <Dialog>
+    <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>{children}</DialogTrigger>
       <DialogContent
         className="bg-gray-900 text-white border border-twitch/40 shadow-[0_0_30px_#9145FE] animate-glow"


### PR DESCRIPTION
## Summary
- maintain open state for Dashboard pop-ups to prevent rapid toggle

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684150a8f2a48333b82316b9d1e6f473