### PR TITLE
Add wavy marker-style underline to tagline

### DIFF
--- a/src/pages/Services.tsx
+++ b/src/pages/Services.tsx
@@ -79,7 +79,15 @@ const Services = ({ onBackHome }: ServicesProps) => {
           <h1 className="text-6xl font-bold text-white mb-6 animate-slide-up">
             Twitch Services
           </h1>
-          <p className="text-2xl text-gray-300 italic animate-slide-up" style={{ animationDelay: '0.2s' }}>
+          <p
+            className="text-2xl text-gray-300 italic animate-slide-up"
+            style={{
+              animationDelay: '0.2s',
+              textDecorationLine: 'underline',
+              textDecorationColor: '#9145FE',
+              textDecorationStyle: 'wavy',
+            }}
+          >
             "Earn money just by streaming."
           </p>
         </div>


### PR DESCRIPTION
## Summary
- update Services tagline styling with a wavy purple underline

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684172e5b8648333af54829df354c965