### PR TITLE
Fix styling for services tagline

### DIFF
--- a/src/pages/Services.tsx
+++ b/src/pages/Services.tsx
@@ -82,10 +82,7 @@ const Services = ({ onBackHome }: ServicesProps) => {
           <p
             className="text-2xl text-gray-300 italic animate-slide-up"
             style={{
-              animationDelay: '0.2s',
-              textDecorationLine: 'underline',
-              textDecorationColor: '#9145FE',
-              textDecorationStyle: 'wavy',
+              animationDelay: '0.2s'
             }}
           >
             "Earn money just by streaming."


### PR DESCRIPTION
## Summary
- remove underline styling from the Services page introduction

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684174e013f88333adefbb4137022c54