### PR TITLE
Update revenue bars

### DIFF
--- a/src/components/TestimonialCard.tsx
+++ b/src/components/TestimonialCard.tsx
@@ -19,6 +19,8 @@ const TestimonialCard = ({ name, testimonial, earnings, imageLeft, showConnector
       revenue: 800 + i * 20 + Math.round(Math.sin(i / 3) * 100)
     }));
 
+  const progress = Math.min(100, (stats.moneyEarned / 2000) * 100);
+
   return (
     <div className="relative py-16">
       <div className={`flex flex-col lg:flex-row items-center gap-12 ${imageLeft ? 'lg:flex-row' : 'lg:flex-row-reverse'}`}>
@@ -35,11 +37,14 @@ const TestimonialCard = ({ name, testimonial, earnings, imageLeft, showConnector
               </div>
               <div className="space-y-3">
                 <div className="flex justify-between items-center">
-                  <span className="text-gray-300">Total Earnings</span>
+                  <span className="text-gray-300">Ads revenues</span>
                   <span className="text-twitch font-bold text-xl">{earnings}</span>
                 </div>
                 <div className="w-full bg-gray-800 rounded-full h-2">
-                  <div className="bg-twitch h-2 rounded-full w-full animate-pulse-glow"></div>
+                  <div
+                    className="bg-twitch h-2 rounded-full animate-pulse-glow"
+                    style={{ width: `${progress}%` }}
+                  ></div>
                 </div>
                 <div className="grid grid-cols-2 gap-4 text-sm">
                   <div>

--- a/src/pages/Services.tsx
+++ b/src/pages/Services.tsx
@@ -22,34 +22,34 @@ const testimonialData = [
   {
     name: "XXXXX",
     testimonial: "Working with Wammy's Agency has been a game-changer for my streaming career. They helped me increase my ad revenue by 400% while maintaining my authentic content style.",
-    earnings: "$3,200",
+    earnings: "$1,815",
     imageLeft: true,
     streamData: generateStreams(1, 3),
-    stats: { moneyEarned: 3200, increasePercent: 400 }
+    stats: { moneyEarned: 1815, increasePercent: 400 }
   },
   {
     name: "XXXXX",
     testimonial: "The professionalism and results speak for themselves. In just 3 months, I went from struggling to pay bills to having a stable income from streaming.",
-    earnings: "$2,800",
+    earnings: "$1,029",
     imageLeft: false,
     streamData: generateStreams(2, 4),
-    stats: { moneyEarned: 2800, increasePercent: 350 }
+    stats: { moneyEarned: 1029, increasePercent: 350 }
   },
   {
     name: "XXXXX",
     testimonial: "I was skeptical at first, but Wammy's delivered exactly what they promised. The ad optimization strategies they implemented are incredible.",
-    earnings: "$4,100",
+    earnings: "$1,958",
     imageLeft: true,
     streamData: generateStreams(0.5, 5),
-    stats: { moneyEarned: 4100, increasePercent: 420 }
+    stats: { moneyEarned: 1958, increasePercent: 420 }
   },
   {
     name: "XXXXX",
     testimonial: "Finally, an agency that understands Twitch and actually cares about their partners' success. The transparency and support are unmatched.",
-    earnings: "$2,500",
+    earnings: "$1,539",
     imageLeft: false,
     streamData: generateStreams(1.5, 2),
-    stats: { moneyEarned: 2500, increasePercent: 275 }
+    stats: { moneyEarned: 1539, increasePercent: 275 }
   }
 ];
 


### PR DESCRIPTION
## Summary
- change revenue bar label to "Ads revenues"
- set bar width based on the earnings
- adjust testimonial earnings

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68418dd77f6c8333b051a7ae89daabfc