### PR TITLE
Update Twitch dashboard data

### DIFF
--- a/src/components/TestimonialCard.tsx
+++ b/src/components/TestimonialCard.tsx
@@ -9,9 +9,19 @@ interface TestimonialCardProps {
   showConnector?: boolean;
   streamData?: RevenuePoint[];
   stats: { moneyEarned: number; increasePercent: number };
+  adsWithoutUs: number;
 }
 
-const TestimonialCard = ({ name, testimonial, earnings, imageLeft, showConnector = true, streamData, stats }: TestimonialCardProps) => {
+const TestimonialCard = ({
+  name,
+  testimonial,
+  earnings,
+  imageLeft,
+  showConnector = true,
+  streamData,
+  stats,
+  adsWithoutUs
+}: TestimonialCardProps) => {
   const chartData =
     streamData ||
     Array.from({ length: 30 }, (_, i) => ({
@@ -20,6 +30,14 @@ const TestimonialCard = ({ name, testimonial, earnings, imageLeft, showConnector
     }));
 
   const progress = Math.min(100, (stats.moneyEarned / 2000) * 100);
+  const withoutUsFormatted = new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    maximumFractionDigits: 0
+  }).format(adsWithoutUs);
+  const adIncreasePercent = Math.round(
+    ((stats.moneyEarned - adsWithoutUs) / adsWithoutUs) * 100
+  );
 
   return (
     <div className="relative py-16">
@@ -49,11 +67,11 @@ const TestimonialCard = ({ name, testimonial, earnings, imageLeft, showConnector
                 <div className="grid grid-cols-2 gap-4 text-sm">
                   <div>
                     <div className="text-gray-400">Ad Revenue</div>
-                    <div className="text-green-400 font-semibold">+247%</div>
+                    <div className="text-green-400 font-semibold">+{adIncreasePercent}%</div>
                   </div>
                   <div>
-                    <div className="text-gray-400">Views</div>
-                    <div className="text-blue-400 font-semibold">+180%</div>
+                    <div className="text-gray-400">Ads revenues without us</div>
+                    <div className="text-blue-400 font-semibold">{withoutUsFormatted}</div>
                   </div>
                 </div>
               </div>

--- a/src/pages/Services.tsx
+++ b/src/pages/Services.tsx
@@ -23,6 +23,7 @@ const testimonialData = [
     name: "XXXXX",
     testimonial: "Working with Wammy's Agency has been a game-changer for my streaming career. They helped me increase my ad revenue by 400% while maintaining my authentic content style.",
     earnings: "$1,815",
+    adsWithoutUs: 159,
     imageLeft: true,
     streamData: generateStreams(1, 3),
     stats: { moneyEarned: 1815, increasePercent: 400 }
@@ -31,6 +32,7 @@ const testimonialData = [
     name: "XXXXX",
     testimonial: "The professionalism and results speak for themselves. In just 3 months, I went from struggling to pay bills to having a stable income from streaming.",
     earnings: "$1,029",
+    adsWithoutUs: 120,
     imageLeft: false,
     streamData: generateStreams(2, 4),
     stats: { moneyEarned: 1029, increasePercent: 350 }
@@ -39,6 +41,7 @@ const testimonialData = [
     name: "XXXXX",
     testimonial: "I was skeptical at first, but Wammy's delivered exactly what they promised. The ad optimization strategies they implemented are incredible.",
     earnings: "$1,958",
+    adsWithoutUs: 95,
     imageLeft: true,
     streamData: generateStreams(0.5, 5),
     stats: { moneyEarned: 1958, increasePercent: 420 }
@@ -47,6 +50,7 @@ const testimonialData = [
     name: "XXXXX",
     testimonial: "Finally, an agency that understands Twitch and actually cares about their partners' success. The transparency and support are unmatched.",
     earnings: "$1,539",
+    adsWithoutUs: 163,
     imageLeft: false,
     streamData: generateStreams(1.5, 2),
     stats: { moneyEarned: 1539, increasePercent: 275 }
@@ -121,6 +125,7 @@ const Services = ({ onBackHome }: ServicesProps) => {
                 name={testimonial.name}
                 testimonial={testimonial.testimonial}
                 earnings={testimonial.earnings}
+                adsWithoutUs={testimonial.adsWithoutUs}
                 imageLeft={testimonial.imageLeft}
                 streamData={testimonial.streamData}
                 stats={testimonial.stats}


### PR DESCRIPTION
## Summary
- swap out the `Views` metric on dashboard cards for **Ads revenues without us**
- provide baseline revenue values for each testimonial
- compute the ad revenue growth percentage dynamically

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68418fa682248333bf56b74efabec3f4