### PR TITLE
Add streamer photos

### DIFF
--- a/src/components/TestimonialCard.tsx
+++ b/src/components/TestimonialCard.tsx
@@ -7,6 +7,7 @@ interface TestimonialCardProps {
   testimonial: string;
   earnings: string;
   imageLeft: boolean;
+  imageSrc?: string;
   showConnector?: boolean;
   streamData?: RevenuePoint[];
   stats: { moneyEarned: number; increasePercent: number };
@@ -24,6 +25,7 @@ const TestimonialCard = ({
   testimonial,
   earnings,
   imageLeft,
+  imageSrc,
   showConnector = true,
   streamData,
   stats,
@@ -143,16 +145,25 @@ const TestimonialCard = ({
 
         {/* Testimonial */}
         <div className="flex-1 text-center lg:text-left">
-          <div className="bg-gray-900/50 backdrop-blur-sm rounded-2xl p-8 border border-gray-700/70 shadow-lg relative">
+          <div className="bg-gray-900/50 backdrop-blur-sm rounded-2xl p-8 border border-gray-700/70 shadow-lg relative transition-all hover:shadow-2xl hover:-translate-y-1">
             <div className="absolute inset-0 bg-gradient-to-r from-twitch/5 to-transparent rounded-2xl"></div>
             <div className="relative">
               <div className="text-6xl text-twitch/30 mb-4">"</div>
               <p className="text-gray-300 text-lg mb-6 italic leading-relaxed">
                 {testimonial}
               </p>
-              <div className="text-twitch font-semibold text-xl">— {name}</div>
-              <div className="text-gray-400 text-sm">
-                Twitch Partner
+              <div className="flex items-center justify-center lg:justify-start gap-4 mt-6">
+                {imageSrc && (
+                  <img
+                    src={imageSrc}
+                    alt={`${name} avatar`}
+                    className="w-16 h-16 rounded-full object-cover filter blur-sm ring-2 ring-gray-300/70 animate-glow"
+                  />
+                )}
+                <div>
+                  <div className="text-twitch font-semibold text-xl">— {name}</div>
+                  <div className="text-gray-400 text-sm">Twitch Partner</div>
+                </div>
               </div>
             </div>
           </div>

--- a/src/pages/Services.tsx
+++ b/src/pages/Services.tsx
@@ -48,6 +48,7 @@ const testimonialData = [
     testimonial: "Working with Wammy's Agency has been a game-changer for my streaming career. They helped me increase my ad revenue by 400% while maintaining my authentic content style.",
     earnings: "$2,115",
     adsWithoutUs: 159,
+    imageSrc: "/streamers/FlannelJax.png",
     imageLeft: true,
     streamData: streamer1Data,
     stats: { moneyEarned: 2115, increasePercent: 400 },
@@ -58,6 +59,7 @@ const testimonialData = [
     testimonial: "The professionalism and results speak for themselves. In just 3 months, I went from struggling to pay bills to having a stable income from streaming.",
     earnings: "$1,229",
     adsWithoutUs: 120,
+    imageSrc: "/streamers/Rafsou.png",
     imageLeft: false,
     streamData: streamer2Data,
     stats: { moneyEarned: 1229, increasePercent: 350 },
@@ -68,6 +70,7 @@ const testimonialData = [
     testimonial: "I was skeptical at first, but Wammy's delivered exactly what they promised. The ad optimization strategies they implemented are incredible.",
     earnings: "$2,324",
     adsWithoutUs: 95,
+    imageSrc: "/streamers/soldier",
     imageLeft: true,
     streamData: streamer3Data,
     stats: { moneyEarned: 2324, increasePercent: 420 },
@@ -78,6 +81,7 @@ const testimonialData = [
     testimonial: "Finally, an agency that understands Twitch and actually cares about their partners' success. The transparency and support are unmatched.",
     earnings: "$1,530",
     adsWithoutUs: 163,
+    imageSrc: "/streamers/yeri.png",
     imageLeft: false,
     streamData: streamer4Data,
     stats: { moneyEarned: 1530, increasePercent: 275 },
@@ -154,6 +158,7 @@ const Services = ({ onBackHome }: ServicesProps) => {
                 testimonial={testimonial.testimonial}
                 earnings={testimonial.earnings}
                 adsWithoutUs={testimonial.adsWithoutUs}
+                imageSrc={testimonial.imageSrc}
                 imageLeft={testimonial.imageLeft}
                 streamData={testimonial.streamData}
                 stats={testimonial.stats}


### PR DESCRIPTION
## Summary
- show blurred streamer photos with a glow effect in testimonials
- allow TestimonialCard to receive an image
- add hover shadow effect to testimonial cards

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6841a702e6788333b06f6125ff4172b2