### PR TITLE
Add purple animated border

### DIFF
--- a/src/components/StreamStatsDialog.tsx
+++ b/src/components/StreamStatsDialog.tsx
@@ -19,7 +19,7 @@ const StreamStatsDialog = ({
 }: StreamStatsDialogProps) => (
   <Dialog>
     <DialogTrigger asChild>{trigger}</DialogTrigger>
-    <DialogContent className="bg-gray-900 text-white border-gray-700 max-w-xl">
+    <DialogContent className="bg-gray-900 text-white border-gray-700 max-w-xl animated-border-gradient">
       <DialogHeader>
         <DialogTitle>Ad Revenue by streams - 30 days</DialogTitle>
       </DialogHeader>

--- a/src/components/TestimonialCard.tsx
+++ b/src/components/TestimonialCard.tsx
@@ -146,7 +146,7 @@ const TestimonialCard = ({
         {/* Testimonial */}
         <div className="flex-1 text-center lg:text-left">
           <div
-            className={`bg-gray-900/50 backdrop-blur-sm rounded-2xl p-8 border border-gray-700/70 shadow-xl relative transition-all duration-300 transform-gpu [transform:perspective(800px)] hover:shadow-2xl ${
+            className={`bg-gray-900/50 backdrop-blur-sm rounded-2xl p-8 border border-gray-700/70 shadow-xl transition-all duration-300 transform-gpu [transform:perspective(800px)] hover:shadow-2xl animated-border-gradient ${
               imageLeft
                 ? 'hover:[transform:perspective(800px)_rotateY(-8deg)_rotateX(3deg)_translateY(-0.5rem)]'
                 : 'hover:[transform:perspective(800px)_rotateY(8deg)_rotateX(3deg)_translateY(-0.5rem)]'

--- a/src/index.css
+++ b/src/index.css
@@ -99,3 +99,34 @@
     @apply bg-background text-foreground;
   }
 }
+
+.animated-border-gradient {
+  position: relative;
+  z-index: 0;
+}
+
+.animated-border-gradient::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  padding: 2px;
+  border-radius: inherit;
+  background: linear-gradient(120deg, #9145FE, #B368FF, #9145FE);
+  background-size: 200% 200%;
+  filter: blur(6px);
+  animation: border-gradient 6s linear infinite;
+  pointer-events: none;
+  -webkit-mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+  -webkit-mask-composite: xor;
+          mask-composite: exclude;
+}
+
+@keyframes border-gradient {
+  0%,
+  100% {
+    background-position: 0% 50%;
+  }
+  50% {
+    background-position: 100% 50%;
+  }
+}

--- a/src/pages/Services.tsx
+++ b/src/pages/Services.tsx
@@ -130,12 +130,18 @@ const Services = ({ onBackHome }: ServicesProps) => {
 
         {/* Stats Section */}
         <div className="grid md:grid-cols-2 gap-12 mb-20">
-          <div className="relative text-center p-8 bg-gray-900/30 rounded-2xl border border-gray-700 shadow-lg animate-slide-up" style={{ animationDelay: '0.4s' }}>
+          <div
+            className="text-center p-8 bg-gray-900/30 rounded-2xl border border-gray-700 shadow-lg animate-slide-up animated-border-gradient"
+            style={{ animationDelay: '0.4s' }}
+          >
             <div className="text-gray-400 text-lg mb-4">Total Generated</div>
             <AnimatedCounter target={TOTAL_GENERATED} prefix="$" />
             <div className="text-gray-500 text-sm mt-2">For our partners</div>
           </div>
-          <div className="relative text-center p-8 bg-gray-900/30 rounded-2xl border border-gray-700 shadow-lg animate-slide-up" style={{ animationDelay: '0.6s' }}>
+          <div
+            className="text-center p-8 bg-gray-900/30 rounded-2xl border border-gray-700 shadow-lg animate-slide-up animated-border-gradient"
+            style={{ animationDelay: '0.6s' }}
+          >
             <div className="text-gray-400 text-lg mb-4">Streamers Collaborated</div>
             <AnimatedCounter target={STREAMERS_COLLABORATED} />
             <div className="text-gray-500 text-sm mt-2">And counting</div>


### PR DESCRIPTION
## Summary
- add animated border gradient utility
- style stats boxes with glow
- highlight testimonial cards
- add glow to stats popup

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6841e6842090833391be02cfe91bb875