### PR TITLE
Fix dialog alignment and overlay

### DIFF
--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -16,7 +16,7 @@ const AlertDialogPortal = ({
   <AlertDialogPrimitive.Portal {...props}>
     <div
       className={cn(
-        "fixed inset-0 z-50 flex items-start justify-center sm:items-center",
+        "fixed inset-0 z-50 flex items-center justify-center",
         className
       )}
     >
@@ -31,7 +31,7 @@ const AlertDialogOverlay = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <AlertDialogPrimitive.Overlay
     className={cn(
-      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "fixed inset-0 z-40 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className
     )}
     {...props}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -16,7 +16,7 @@ const DialogPortal = ({
   <DialogPrimitive.Portal {...props}>
     <div
       className={cn(
-        "fixed inset-0 z-50 flex items-start justify-center sm:items-center",
+        "fixed inset-0 z-50 flex items-center justify-center",
         className
       )}
     >
@@ -34,7 +34,7 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "fixed inset-0 z-40 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className
     )}
     {...props}


### PR DESCRIPTION
## Summary
- keep modals centered by default
- ensure overlay sits behind dialog content

## Testing
- `npm run lint` *(fails: cannot find module '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841e9a82da883339c0d41a449a5fc20