### PR TITLE
Fix border gradient z-index on dialogs

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -102,10 +102,10 @@
 
 .animated-border-gradient {
   position: relative;
-  z-index: 0;
 }
 
 .animated-border-gradient::before {
+  z-index: -1;
   content: "";
   position: absolute;
   inset: 0;


### PR DESCRIPTION
## Summary
- avoid overriding z-index with the border gradient

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6841ed8a92588333afa95f679eae58b8